### PR TITLE
updates dependency versions

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,12 +3,12 @@
   :url "https://github.com/drapanjanas/pneumatic-tubes"
   :license {:name "Eclipse Public License"
             :url  "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0-alpha14"]
+  :dependencies [[org.clojure/clojure "1.9.0-alpha15"]
                  [org.clojure/clojurescript "1.9.293"]
                  [org.clojure/tools.logging "0.3.1"]
-                 [org.clojure/core.async "0.2.395"]
+                 [org.clojure/core.async "0.3.442"]
                  [com.cognitect/transit-cljs "0.8.239"]
-                 [com.cognitect/transit-clj "0.8.293"]
+                 [com.cognitect/transit-clj "0.8.300"]
                  [http-kit "2.2.0"]]
 
   :scm {:name "git"


### PR DESCRIPTION
I was getting a bunch of `core` spec conformance validation errors trying to bring in `pneumatic-tubes 0.1.0`  and then also with a locally installed, unmodified `pneumatic-tubes 0.2.0-SNAPSHOT` into an existing http-kit / core-async project.

updating dependency version(s) evidently fixed the issue.